### PR TITLE
Fix import statement in example code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -217,7 +217,7 @@ The simple case works exactly the same as with `ProcessPoolExecutor`_:
 
 .. code-block:: python
 
-    from deadpool import Deadpool
+    import deadpool
 
     def f():
         return 123


### PR DESCRIPTION
Adapt the import statement from the first example code block to avoid an error and align with the import statements in following code blocks.