### PR TITLE
Track all created workers in a weakset

### DIFF
--- a/deadpool.py
+++ b/deadpool.py
@@ -464,7 +464,6 @@ class Deadpool(Executor):
         # The `1` is for `wp` itself.
         total_workers = count_workers_busy + count_workers_idle + 1
         there_are_more_workers_than_min = total_workers > self.min_workers
-        there_are_idle_workers = count_workers_idle > 0
         task_backlog_is_empty = backlog_size == 0
 
         # if there_are_more_workers_than_min and (there_are_idle_workers or task_backlog_is_empty):

--- a/deadpool.py
+++ b/deadpool.py
@@ -32,6 +32,7 @@ import traceback
 import typing
 import weakref
 import atexit
+import json
 from concurrent.futures import CancelledError, Executor, InvalidStateError, as_completed
 from dataclasses import dataclass, field
 from multiprocessing.connection import Connection
@@ -69,6 +70,44 @@ logger = logging.getLogger("deadpool")
 #         tracker._stop()
 #     except Exception:
 #         logger.info("Error stopping the multiprocessing resource tracker")
+
+@dataclass
+class Stat:
+    lock: threading.Lock
+    value: int = 0
+
+    def increment(self, value: int = 1):
+        with self.lock:
+            self.value += value
+
+    def set(self, reset_value: int = 0):
+        self.value = reset_value
+
+class Statistics:
+    def __init__(self):
+        self._lock = threading.Lock()
+
+        self.tasks_received = Stat(self._lock, 0)
+        self.tasks_launched = Stat(self._lock, 0)
+        self.tasks_failed = Stat(self._lock, 0)
+        self.worker_processes_created = Stat(self._lock, 0)
+        self.max_workers_busy_concurrently = Stat(self._lock, 0)
+
+    def reset_counters(self):
+        self.tasks_received.set()
+        self.tasks_launched.set()
+        self.tasks_failed.set()
+        self.worker_processes_created.set()
+        self.max_workers_busy_concurrently.set()
+
+    def to_dict(self) -> dict[str, typing.Any]:
+        return {
+            "tasks_received": self.tasks_received.value,
+            "tasks_launched": self.tasks_launched.value,
+            "tasks_failed": self.tasks_failed.value,
+            "worker_processes_created": self.worker_processes_created.value,
+            "max_workers_busy_concurrently": self.max_workers_busy_concurrently.value,
+        }
 
 
 @dataclass(order=True)
@@ -285,6 +324,7 @@ class Deadpool(Executor):
         self.malloc_trim_rss_memory_threshold_bytes = (
             malloc_trim_rss_memory_threshold_bytes
         )
+        self._statistics = Statistics()
 
         # TODO: overcommit
         self.workers: SimpleQueue[WorkerProcess] = SimpleQueue()
@@ -303,6 +343,18 @@ class Deadpool(Executor):
             target=self.runner, name="deadpool.runner", daemon=True
         )
         self.runner_thread.start()
+
+    def get_statistics(self) -> dict[str, typing.Any]:
+        stats = self._statistics.to_dict()
+
+        # These are not counters; they are determined at the time of the
+        # call based on the state of the worker processes.
+        stats["worker_processes_still_alive"] = len(self.existing_workers)
+        stats["worker_processes_idle"] = self.workers.qsize()
+        stats["worker_processes_busy"] = len(self.busy_workers)
+
+        return stats
+
 
     def add_worker_to_pool(self):
         if self.propagate_environ:
@@ -333,6 +385,7 @@ class Deadpool(Executor):
             malloc_trim_rss_memory_threshold_bytes=self.malloc_trim_rss_memory_threshold_bytes,
         )
         self.workers.put(worker)
+        self._statistics.worker_processes_created.increment()
         self.existing_workers.add(worker)
 
     def clear_workers(self):
@@ -375,6 +428,7 @@ class Deadpool(Executor):
                 continue
 
             t = threading.Thread(target=self.run_task, args=job, daemon=True)
+            self._statistics.tasks_launched.increment()
             t.start()
 
     def get_process(self) -> WorkerProcess:
@@ -388,17 +442,31 @@ class Deadpool(Executor):
 
         wp = self.workers.get()
         self.busy_workers.add(wp)
+        if len(self.busy_workers) > self._statistics.max_workers_busy_concurrently.value:
+            self._statistics.max_workers_busy_concurrently.value = len(self.busy_workers)
+
         return wp
 
     def done_with_process(self, wp: WorkerProcess):
+        # This worker is done with its job and is no longer busy.
         self.busy_workers.remove(wp)
 
-        bw = len(self.busy_workers)
-        mw = self.min_workers
-        qs = self.workers.qsize()
+        count_workers_busy = len(self.busy_workers)
+        count_workers_idle = self.workers.qsize()
+        backlog_size = self.submitted_jobs.qsize()
 
-        total_workers = bw + qs
-        if total_workers > mw and qs > 0:
+        # The `1` is for `wp` itself.
+        total_workers = count_workers_busy + count_workers_idle + 1
+        there_are_more_workers_than_min = total_workers > self.min_workers
+        there_are_idle_workers = count_workers_idle > 0
+        task_backlog_is_empty = backlog_size == 0
+
+        # if there_are_more_workers_than_min and (there_are_idle_workers or task_backlog_is_empty):
+        if there_are_more_workers_than_min and task_backlog_is_empty:
+            # We have more workers than the minimum, and there is no backlog of
+            # tasks. This implies any tasks currently in play have already been picked
+            # up by workers in the pool, or the pool is idle. We can safely remove
+            # this worker from the pool.
             wp.shutdown(wait=False)
             return
 
@@ -456,7 +524,10 @@ class Deadpool(Executor):
                     #  where the worker process often OOMs. As such, not sure
                     #  whether logging at warning level is appropriate.
                     logger.warning(f"BrokenPipeError on {worker.pid}, retrying.")
+                    worker.ok = False
                     self.done_with_process(worker)
+                    # TODO: probably this should be moved into the `done_with_process`
+                    #  and can act on the `worker.ok` flag.
                     kill_proc_tree(worker.pid, sig=signal.SIGKILL)
             else:
                 # If we get here, we've tried to submit the job to a worker
@@ -474,19 +545,23 @@ class Deadpool(Executor):
                     try:
                         results = worker.get_results()
                     except EOFError:
+                        self._statistics.tasks_failed.increment()
                         fut.set_exception(
                             ProcessError("Worker process died unexpectedly")
                         )
                     except BaseException as e:
+                        self._statistics.tasks_failed.increment()
                         logger.debug(f"Unexpected exception from worker: {e}")
                         fut.set_exception(e)
                     else:
                         if isinstance(results, BaseException):
+                            self._statistics.tasks_failed.increment()
                             fut.set_exception(results)
                         else:
                             fut.set_result(results)
 
                         if isinstance(results, TimeoutError):
+                            self._statistics.tasks_failed.increment()
                             logger.debug(
                                 f"TimeoutError on {worker.pid}, setting ok=False"
                             )
@@ -494,6 +569,7 @@ class Deadpool(Executor):
                     finally:
                         break
                 elif not worker.is_alive():
+                    self._statistics.tasks_failed.increment()
                     logger.debug(f"p is no longer alive: {worker.process}")
                     try:
                         signame = signal.strsignal(-worker.process.exitcode)
@@ -556,6 +632,7 @@ class Deadpool(Executor):
                 item=(fn, args, kwargs, deadpool_timeout, fut),
             )
         )
+        self._statistics.tasks_received.increment()
         return fut
 
     def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:

--- a/deadpool.py
+++ b/deadpool.py
@@ -277,6 +277,7 @@ class Deadpool(Executor):
         )
         self.running_jobs = Queue(maxsize=self.pool_size)
         self.running_futs = weakref.WeakSet()
+        self.existing_workers = weakref.WeakSet()
         self.closed = False
         self.shutdown_wait = shutdown_wait
         self.shutdown_cancel_futures = shutdown_cancel_futures
@@ -332,6 +333,7 @@ class Deadpool(Executor):
             malloc_trim_rss_memory_threshold_bytes=self.malloc_trim_rss_memory_threshold_bytes,
         )
         self.workers.put(worker)
+        self.existing_workers.add(worker)
 
     def clear_workers(self):
         """Clear all workers from the pool.

--- a/deadpool.py
+++ b/deadpool.py
@@ -71,6 +71,7 @@ logger = logging.getLogger("deadpool")
 #     except Exception:
 #         logger.info("Error stopping the multiprocessing resource tracker")
 
+
 @dataclass
 class Stat:
     lock: threading.Lock
@@ -82,6 +83,7 @@ class Stat:
 
     def set(self, reset_value: int = 0):
         self.value = reset_value
+
 
 class Statistics:
     def __init__(self):
@@ -355,7 +357,6 @@ class Deadpool(Executor):
 
         return stats
 
-
     def add_worker_to_pool(self):
         if self.propagate_environ:
             # By constructing here, late, we allow the user to make
@@ -442,8 +443,13 @@ class Deadpool(Executor):
 
         wp = self.workers.get()
         self.busy_workers.add(wp)
-        if len(self.busy_workers) > self._statistics.max_workers_busy_concurrently.value:
-            self._statistics.max_workers_busy_concurrently.value = len(self.busy_workers)
+        if (
+            len(self.busy_workers)
+            > self._statistics.max_workers_busy_concurrently.value
+        ):
+            self._statistics.max_workers_busy_concurrently.value = len(
+                self.busy_workers
+            )
 
         return wp
 

--- a/deadpool.py
+++ b/deadpool.py
@@ -81,8 +81,8 @@ class Stat:
         with self.lock:
             self.value += value
 
-    def set(self, reset_value: int = 0):
-        self.value = reset_value
+    def set(self, value: int = 0):
+        self.value = value
 
 
 class Statistics:
@@ -535,7 +535,7 @@ class Deadpool(Executor):
                     # TODO: probably this should be moved into the `done_with_process`
                     #  and can act on the `worker.ok` flag.
                     kill_proc_tree(worker.pid, sig=signal.SIGKILL)
-            else:
+            else:  # pragma: no cover
                 # If we get here, we've tried to submit the job to a worker
                 # process multiple times and failed each time. We're giving
                 # up.

--- a/examples/leftover.py
+++ b/examples/leftover.py
@@ -28,7 +28,7 @@ def main():
             time.sleep(random.randrange(0, 10) / 10)
             w = random.randrange(0, 50) / 10
             exe.submit(worker, results, w, deadpool_timeout=4)
-            print(f"{exe.workers.qsize()=} {len(exe.busy_workers)=}")
+            print(f"{exe.workers.qsize()=} {len(exe.busy_workers)=} {len(exe.existing_workers)=}")
 
     outcome = []
     while not results.empty():

--- a/examples/leftover.py
+++ b/examples/leftover.py
@@ -28,7 +28,9 @@ def main():
             time.sleep(random.randrange(0, 10) / 10)
             w = random.randrange(0, 50) / 10
             exe.submit(worker, results, w, deadpool_timeout=4)
-            print(f"{exe.workers.qsize()=} {len(exe.busy_workers)=} {len(exe.existing_workers)=}")
+            print(
+                f"{exe.workers.qsize()=} {len(exe.busy_workers)=} {len(exe.existing_workers)=}"
+            )
 
     outcome = []
     while not results.empty():

--- a/tests/test_deadpool.py
+++ b/tests/test_deadpool.py
@@ -297,7 +297,10 @@ def test_simple_batch(logging_initializer):
     assert results == [0.1] * 2
 
 
-@pytest.mark.parametrize("ctx", ["spawn", "forkserver", mp.get_context("spawn"), mp.get_context("forkserver")])
+@pytest.mark.parametrize(
+    "ctx",
+    ["spawn", "forkserver", mp.get_context("spawn"), mp.get_context("forkserver")],
+)
 def test_ctx(logging_initializer, ctx):
     with deadpool.Deadpool(mp_context=ctx, initializer=logging_initializer) as exe:
         fut = exe.submit(t, 0.05)

--- a/tests/test_deadpool.py
+++ b/tests/test_deadpool.py
@@ -54,7 +54,7 @@ def test_cancel_all_futures():
 
 @pytest.mark.parametrize("malloc_threshold", [None, 0, 1_000_000])
 @pytest.mark.parametrize("daemon", [True, False])
-@pytest.mark.parametrize("min_workers", [None, 0])
+@pytest.mark.parametrize("min_workers", [None, 10])
 def test_simple(malloc_threshold, daemon, min_workers):
     with deadpool.Deadpool(
         malloc_trim_rss_memory_threshold_bytes=malloc_threshold,


### PR DESCRIPTION
This will be using for monitoring whether all created processes really are handled and there are no leaks (processes still running but not represented in the pool, or `running_futs`, or somewhere else in the system)